### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/src/app/api/admin/newsletter/[id]/send/route.ts
+++ b/src/app/api/admin/newsletter/[id]/send/route.ts
@@ -45,11 +45,28 @@ export async function POST(
     return NextResponse.json({ error: '目前沒有活躍的訂閱者' }, { status: 400 });
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin;
+  const configuredBaseUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!configuredBaseUrl) {
+    return NextResponse.json({ error: '站點網址未設定' }, { status: 500 });
+  }
+
+  let baseUrl: string;
+  try {
+    const parsedBaseUrl = new URL(configuredBaseUrl);
+    if (parsedBaseUrl.protocol !== 'http:' && parsedBaseUrl.protocol !== 'https:') {
+      throw new Error('Invalid protocol');
+    }
+    baseUrl = parsedBaseUrl.origin;
+  } catch {
+    return NextResponse.json({ error: '站點網址設定無效' }, { status: 500 });
+  }
+
   let sentCount = 0;
 
   for (const subscriber of subscribers) {
-    const unsubscribeUrl = `${baseUrl}/api/newsletter/unsubscribe?token=${subscriber.unsubscribe_token}`;
+    const unsubscribeLink = new URL('/api/newsletter/unsubscribe', baseUrl);
+    unsubscribeLink.searchParams.set('token', subscriber.unsubscribe_token);
+    const unsubscribeUrl = unsubscribeLink.toString();
     const html = newsletterWrapperEmail(newsletter.content_html, unsubscribeUrl);
 
     const result = await sendEmail({


### PR DESCRIPTION
Potential fix for [https://github.com/foylaou/yong-an-tea/security/code-scanning/1](https://github.com/foylaou/yong-an-tea/security/code-scanning/1)

Use a trusted canonical site URL only, and reject/fallback if it is not a valid `http/https` URL. Do **not** use `request.nextUrl.origin` as fallback for email link generation. Then safely build unsubscribe links with `URL`/`URLSearchParams` so token values are encoded before insertion into HTML attributes.

Best single fix without changing functionality:
- Edit `src/app/api/admin/newsletter/[id]/send/route.ts`:
  - Replace `const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin;` with strict validation of `process.env.NEXT_PUBLIC_SITE_URL`.
  - Return 500 if env var is missing/invalid.
  - Build `unsubscribeUrl` via `new URL('/api/newsletter/unsubscribe', baseUrl)` and `searchParams.set(...)`.
This removes tainted request-origin from the dataflow and ensures proper URL encoding.

No changes are required in `src/lib/email.ts` for behavior; the dangerous source/path is fixed at construction time in the route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
